### PR TITLE
ci(workflows): try remove setup-node action

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,8 +27,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
-        
       - uses: oven-sh/setup-bun@v2
 
       - name: Setup Pages


### PR DESCRIPTION
refs: https://github.com/oven-sh/setup-bun?tab=readme-ov-file#nodejs-not-needed